### PR TITLE
fix: Lambda Layer module loading - rewrite .js imports to .mjs (#179)

### DIFF
--- a/.claude/rules/lambda-typescript-esm.md
+++ b/.claude/rules/lambda-typescript-esm.md
@@ -1,0 +1,76 @@
+# Lambda TypeScript ESM 规则
+
+> 一次性配置已完成。新增 Lambda 函数时遵循此模式即可。
+
+## 核心规则
+
+### 1. TypeScript 源码：使用 `.js` 扩展名
+
+```typescript
+// ✅ 正确 - TypeScript ESM 约定
+import { logger } from './logger.js';
+import { schema } from './schema.js';
+```
+
+**原因**：TypeScript ESM 规范要求源码中写 `.js`（Node.js 加载时的实际扩展名）
+
+### 2. 编译输出：自动转换为 `.mjs`
+
+编译后自动变成：
+```javascript
+import { logger } from './logger.mjs';  // ✅ esbuild plugin 自动重写
+```
+
+**机制**：`infra/scripts/build-lambdas.mjs` 中的 `rewriteImportsPlugin` 自动处理
+
+### 3. 部署：使用编译后的代码
+
+```bash
+# ✅ 正确流程
+npm run build:lambdas              # 编译到 .lambda-dist/
+cd .lambda-dist/shared-layer && zip ...  # 从编译输出打包
+aws lambda publish-layer-version ...     # 发布 Layer
+```
+
+**错误**：❌ 从 `lambda/shared-layer/` 源码目录打包（会包含 `.ts` 文件）
+
+## 快速检查清单
+
+新增 TypeScript Lambda 时：
+
+- [ ] 源码导入使用 `.js` 扩展名
+- [ ] 运行 `npm run build:lambdas` 编译
+- [ ] 检查 `.lambda-dist/` 中的导入路径是 `.mjs`
+- [ ] 从 `.lambda-dist/` 打包部署（不是源码目录）
+
+## 故障排查
+
+### 症状：`Cannot find module '/opt/nodejs/shared/xxx.js'`
+
+**原因**：编译输出中的导入路径仍然是 `.js`
+
+**检查**：
+```bash
+# 查看编译后的导入语句
+grep "from.*\.js" infra/.lambda-dist/shared-layer/nodejs/shared/*.mjs
+```
+
+**修复**：确认 `build-lambdas.mjs` 使用了 `rewriteImportsPlugin`
+
+## 技术细节
+
+| 工具 | 作用 | 限制 |
+|------|------|------|
+| TypeScript | 编译 `.ts` → `.js` | 不改变导入路径 |
+| esbuild `outExtension` | 输出文件改名 `.js` → `.mjs` | 不改变代码内容 |
+| esbuild `rewriteImportsPlugin` | 重写代码中的导入路径 | ✅ 完整解决方案 |
+
+## 相关文档
+
+- **Build Script**: `infra/scripts/build-lambdas.mjs`
+- **Issue**: #179 - Lambda Layer module loading fix
+- **PR**: #182
+
+---
+
+**一句话总结**：TypeScript 源码写 `.js`，esbuild plugin 自动转 `.mjs`，从 `.lambda-dist/` 部署。

--- a/infra/scripts/build-lambdas.mjs
+++ b/infra/scripts/build-lambdas.mjs
@@ -79,6 +79,27 @@ async function main() {
   }
 }
 
+// esbuild plugin to rewrite .js imports to .mjs
+const rewriteImportsPlugin = {
+  name: 'rewrite-imports',
+  setup(build) {
+    build.onLoad({ filter: /\.ts$/ }, async (args) => {
+      const fs = await import('fs/promises');
+      const contents = await fs.readFile(args.path, 'utf8');
+
+      // Rewrite import/export statements: .js -> .mjs
+      const rewritten = contents
+        .replace(/from\s+['"](\.[^'"]+)\.js['"]/g, "from '$1.mjs'")
+        .replace(/import\s+['"](\.[^'"]+)\.js['"]/g, "import '$1.mjs'");
+
+      return {
+        contents: rewritten,
+        loader: 'ts',
+      };
+    });
+  },
+};
+
 async function buildSharedLayer() {
   const sharedLayerSrc = join(lambdaRoot, 'shared-layer/nodejs/shared');
   const sharedLayerDist = join(distRoot, 'shared-layer/nodejs/shared');
@@ -111,6 +132,7 @@ async function buildSharedLayer() {
     outExtension: {
       '.js': '.mjs', // Output .mjs for ES modules (matches import paths in Lambda functions)
     },
+    plugins: [rewriteImportsPlugin],
     logLevel: 'info',
   });
 
@@ -163,6 +185,7 @@ async function buildLambdaFunctions() {
         outExtension: {
           '.js': '.mjs', // Output .mjs for ES modules
         },
+        plugins: [rewriteImportsPlugin],
         logLevel: 'warning',
       });
       log(`  ✓ Built ${funcName} (TypeScript)`, colors.green);


### PR DESCRIPTION
## Summary
Closes #179

Fixed Critical bug where Lambda instant-processor could not start due to missing compiled JavaScript files in the Lambda Layer.

## Root Cause
The Lambda Layer was being deployed with TypeScript source files instead of compiled JavaScript, causing this error:
```
Cannot find module '/opt/nodejs/shared/logger.js' imported from /opt/nodejs/shared/model-analyzer.mjs
Error [ERR_MODULE_NOT_FOUND]
```

**Technical Details**:
- esbuild's `outExtension: {'.js': '.mjs'}` only renames output files
- Import specifiers inside the code were NOT rewritten (still `.js`)
- TypeScript ESM convention uses `.js` extensions in source imports
- Node.js Lambda runtime requires exact `.mjs` extensions for ESM imports

## Solution
Added `rewriteImportsPlugin` to esbuild configuration that:
1. Intercepts TypeScript files during compilation
2. Rewrites all relative imports from `.js` to `.mjs` using regex
3. Applied to both `shared-layer` and Lambda function builds

**Code Changes**:
- `infra/scripts/build-lambdas.mjs`: Added 23-line esbuild plugin
- Plugin rewrites: `from './logger.js'` → `from './logger.mjs'`

## Verification

### Build Output
```
✓ Built 5 shared-layer modules
✓ Built 15 Lambda functions
```

### Compiled Import Verification
**Before**:
```javascript
import { logger } from "./logger.js";  // ❌ File doesn't exist
```

**After**:
```javascript
import { logger } from "./logger.mjs";  // ✅ File exists
```

### Lambda Deployment
- Published Layer v70 with corrected imports
- Updated all 9 Lambda functions to use Layer v70
- Verified configuration: `Layers[0].Arn = ...layer:yorutsuke-shared-dev:70`

### CloudWatch Logs
**Before (Layer v69)**:
```
ERROR: Cannot find module '/opt/nodejs/shared/logger.js'
```

**After (Layer v70)**:
```
INFO: IMAGE_PROCESSING_STARTED
```

✅ No more "Cannot find module" errors
✅ Lambda initializes successfully
✅ Can process S3 upload events

## Impact
- **Severity**: Critical - All image processing was broken
- **Scope**: All Lambda functions using shared-layer (9 functions)
- **Status**: ✅ Fixed and deployed to dev environment

## Testing
- [x] Build script compiles successfully
- [x] Verified .mjs import paths in compiled code
- [x] Layer v70 published to AWS
- [x] All 9 Lambda functions updated
- [x] Test S3 upload triggered Lambda execution
- [x] CloudWatch logs show successful initialization
- [x] No module errors in recent logs

## Files Changed
- `infra/scripts/build-lambdas.mjs` (+23 lines): esbuild plugin for import rewriting

## Next Steps
After PR merge:
1. Update deployment documentation if needed
2. Monitor production deployment when code reaches master
3. Consider adding integration test for Layer module loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)