### PR TITLE
docs: add PR target branch rule to workflow

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -108,6 +108,42 @@ When you run `*issue close #XXX`, the command automatically:
 
 **No manual work needed** - but verify completion!
 
+## PR Target Branch Rule (CRITICAL)
+
+**ALWAYS create Pull Requests to merge into `development` branch, NOT `master`.**
+
+### PR Creation Checklist (MUST verify before submitting)
+- [ ] Base branch is `development` (NOT master)
+- [ ] Head branch is `feature/XXX-*` or `bugfix/XXX-*`
+- [ ] PR title matches issue title
+- [ ] PR description includes "Closes #XXX"
+
+### Correct PR Command
+```bash
+# ✅ CORRECT - Target development branch
+gh pr create --base development --head feature/XXX-description --title "..." --body "..."
+
+# ❌ WRONG - Never target master directly
+gh pr create --base master --head feature/XXX-description --title "..." --body "..."
+```
+
+### Why Target Development?
+
+| Reason | Benefit |
+|--------|---------|
+| **Controlled releases** | Master only gets stable, tested code from development |
+| **Integration testing** | Features tested together in development before release |
+| **Rollback safety** | Master always represents last known good state |
+| **Clear deployment** | development = staging, master = production |
+
+### Workflow
+```
+feature/XXX → (PR) → development → (tested) → master → production
+```
+
+**Auto-Fix**: If you accidentally created PR to master:
+1. Close the incorrect PR
+2. Recreate with `--base development`
 
 ## Two-Step Planning (新增)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,8 @@ aws lambda publish-layer-version --layer-name yorutsuke-shared-dev --zip-file fi
 
 ## Workflow
 
+**CRITICAL**: All pull requests must target `development` branch, never `master` directly.
+
 ### Core Commands
 
 | Command | Description |


### PR DESCRIPTION
## Summary

Adds explicit documentation that all pull requests must target the `development` branch, not `master` directly. This ensures proper integration testing and controlled releases.

## Changes

### `.claude/rules/workflow.md`
- ✅ Added **PR Target Branch Rule (CRITICAL)** section
- ✅ Included PR creation checklist
- ✅ Provided correct `gh pr create` command examples
- ✅ Explained workflow: `feature → development → master → production`
- ✅ Added auto-fix procedure for incorrect PRs

### `CLAUDE.md`
- ✅ Added one-sentence reminder at top of Workflow section
- ✅ Makes the rule immediately visible in main project file

## Why This Rule?

| Reason | Benefit |
|--------|---------|
| **Controlled releases** | Master only gets stable, tested code from development |
| **Integration testing** | Features tested together in development before release |
| **Rollback safety** | Master always represents last known good state |
| **Clear deployment** | development = staging, master = production |

## Context

This rule was added after PR #185 was accidentally created targeting `master` instead of `development`. The PR was closed and recreated as #186 with the correct target branch.

## Files Changed

| File | Lines Added | Purpose |
|------|-------------|---------|
| `.claude/rules/workflow.md` | +36 | Detailed PR workflow rules |
| `CLAUDE.md` | +2 | Quick reminder for AI |

## Checklist

- [x] Rule clearly documented
- [x] Examples provided
- [x] Rationale explained
- [x] Auto-fix procedure included
- [x] Visible in both detailed rules and main CLAUDE.md

---

**Related**: Issue #184, PR #185 (incorrect), PR #186 (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)